### PR TITLE
Use parse quoted field feature flag

### DIFF
--- a/ext/fastcsv/fastcsv.c
+++ b/ext/fastcsv/fastcsv.c
@@ -40,7 +40,7 @@ typedef struct {
 } Data;
 
 
-#line 156 "ext/fastcsv/fastcsv.rl"
+#line 191 "ext/fastcsv/fastcsv.rl"
 
 
 
@@ -52,7 +52,7 @@ static const int raw_parse_error = 0;
 static const int raw_parse_en_main = 4;
 
 
-#line 159 "ext/fastcsv/fastcsv.rl"
+#line 194 "ext/fastcsv/fastcsv.rl"
 
 // 16 kB
 #define BUFSIZE 16384
@@ -130,7 +130,7 @@ static VALUE raw_parse(int argc, VALUE *argv, VALUE self) {
   VALUE option;
   char quote_char = '"', col_sep = ',';
 
-  bool in_quoted_field = false;
+  bool in_quoted_field = false, use_parse_quoted_field = true;
 
   rb_scan_args(argc, argv, "11", &port, &opts);
   taint = OBJ_TAINTED(port);
@@ -151,6 +151,9 @@ static VALUE raw_parse(int argc, VALUE *argv, VALUE self) {
   else if (TYPE(opts) != T_HASH) {
     rb_raise(rb_eArgError, "options has to be a Hash or nil");
   }
+
+  option = rb_hash_aref(opts, ID2SYM(rb_intern("use_parse_quoted_field")));
+  use_parse_quoted_field = RTEST(option);
 
   option = rb_hash_aref(opts, ID2SYM(rb_intern("quote_char")));
   if (TYPE(option) == T_STRING && RSTRING_LEN(option) == 1) {
@@ -298,7 +301,7 @@ static VALUE raw_parse(int argc, VALUE *argv, VALUE self) {
   }
 
   
-#line 302 "ext/fastcsv/fastcsv.c"
+#line 305 "ext/fastcsv/fastcsv.c"
 	{
 	cs = raw_parse_start;
 	ts = 0;
@@ -306,7 +309,7 @@ static VALUE raw_parse(int argc, VALUE *argv, VALUE self) {
 	act = 0;
 	}
 
-#line 404 "ext/fastcsv/fastcsv.rl"
+#line 442 "ext/fastcsv/fastcsv.rl"
 
   while (!done) {
     VALUE str;
@@ -368,7 +371,7 @@ static VALUE raw_parse(int argc, VALUE *argv, VALUE self) {
 
     pe = p + len;
     
-#line 372 "ext/fastcsv/fastcsv.c"
+#line 375 "ext/fastcsv/fastcsv.c"
 	{
 	short _widec;
 	if ( p == pe )
@@ -399,7 +402,7 @@ tr5:
       ENCODE;
     }
   }
-#line 122 "ext/fastcsv/fastcsv.rl"
+#line 157 "ext/fastcsv/fastcsv.rl"
 	{
     if (d->start == 0 || p == d->start) { // same as new_row
       rb_ivar_set(self, s_row, rb_str_new2(""));
@@ -416,7 +419,7 @@ tr5:
       rb_yield(row);
     }
   }
-#line 154 "ext/fastcsv/fastcsv.rl"
+#line 189 "ext/fastcsv/fastcsv.rl"
 	{te = p+1;}
 	goto st4;
 tr6:
@@ -431,9 +434,9 @@ tr6:
       ENCODE;
     }
   }
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -442,7 +445,7 @@ tr6:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{te = p+1;}
 	goto st4;
 tr7:
@@ -457,9 +460,9 @@ tr7:
       ENCODE;
     }
   }
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -468,9 +471,9 @@ tr7:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{te = p+1;}
-#line 122 "ext/fastcsv/fastcsv.rl"
+#line 157 "ext/fastcsv/fastcsv.rl"
 	{
     if (d->start == 0 || p == d->start) { // same as new_row
       rb_ivar_set(self, s_row, rb_str_new2(""));
@@ -489,7 +492,7 @@ tr7:
   }
 	goto st4;
 tr12:
-#line 122 "ext/fastcsv/fastcsv.rl"
+#line 157 "ext/fastcsv/fastcsv.rl"
 	{
     if (d->start == 0 || p == d->start) { // same as new_row
       rb_ivar_set(self, s_row, rb_str_new2(""));
@@ -506,13 +509,13 @@ tr12:
       rb_yield(row);
     }
   }
-#line 154 "ext/fastcsv/fastcsv.rl"
+#line 189 "ext/fastcsv/fastcsv.rl"
 	{te = p+1;}
 	goto st4;
 tr18:
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -521,13 +524,13 @@ tr18:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{te = p+1;}
 	goto st4;
 tr19:
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -536,9 +539,9 @@ tr19:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{te = p+1;}
-#line 122 "ext/fastcsv/fastcsv.rl"
+#line 157 "ext/fastcsv/fastcsv.rl"
 	{
     if (d->start == 0 || p == d->start) { // same as new_row
       rb_ivar_set(self, s_row, rb_str_new2(""));
@@ -557,11 +560,11 @@ tr19:
   }
 	goto st4;
 tr36:
-#line 154 "ext/fastcsv/fastcsv.rl"
+#line 189 "ext/fastcsv/fastcsv.rl"
 	{te = p;p--;}
 	goto st4;
 tr37:
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -592,7 +595,7 @@ tr37:
 	}
 	goto st4;
 tr43:
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -611,15 +614,15 @@ tr43:
 
     curline++;
   }
-#line 153 "ext/fastcsv/fastcsv.rl"
+#line 188 "ext/fastcsv/fastcsv.rl"
 	{te = p;p--;}
 	goto st4;
 tr44:
-#line 153 "ext/fastcsv/fastcsv.rl"
+#line 188 "ext/fastcsv/fastcsv.rl"
 	{te = p;p--;}
 	goto st4;
 tr45:
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -638,7 +641,7 @@ tr45:
 
     curline++;
   }
-#line 122 "ext/fastcsv/fastcsv.rl"
+#line 157 "ext/fastcsv/fastcsv.rl"
 	{
     if (d->start == 0 || p == d->start) { // same as new_row
       rb_ivar_set(self, s_row, rb_str_new2(""));
@@ -655,13 +658,13 @@ tr45:
       rb_yield(row);
     }
   }
-#line 154 "ext/fastcsv/fastcsv.rl"
+#line 189 "ext/fastcsv/fastcsv.rl"
 	{te = p+1;}
 	goto st4;
 tr51:
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -670,9 +673,9 @@ tr51:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{te = p+1;}
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -693,9 +696,9 @@ tr51:
   }
 	goto st4;
 tr52:
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -704,9 +707,9 @@ tr52:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{te = p+1;}
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -725,7 +728,7 @@ tr52:
 
     curline++;
   }
-#line 122 "ext/fastcsv/fastcsv.rl"
+#line 157 "ext/fastcsv/fastcsv.rl"
 	{
     if (d->start == 0 || p == d->start) { // same as new_row
       rb_ivar_set(self, s_row, rb_str_new2(""));
@@ -753,14 +756,14 @@ st4:
 case 4:
 #line 1 "NONE"
 	{ts = p;}
-#line 757 "ext/fastcsv/fastcsv.c"
+#line 760 "ext/fastcsv/fastcsv.c"
 	_widec = (*p);
 	_widec = (short)(1152 + ((*p) - -128));
 	if ( 
-#line 140 "ext/fastcsv/fastcsv.rl"
+#line 175 "ext/fastcsv/fastcsv.rl"
  (*p) == quote_char  ) _widec += 256;
 	if ( 
-#line 141 "ext/fastcsv/fastcsv.rl"
+#line 176 "ext/fastcsv/fastcsv.rl"
  (*p) == col_sep  ) _widec += 512;
 	switch( _widec ) {
 		case 1280: goto tr27;
@@ -798,10 +801,10 @@ case 1:
 	_widec = (*p);
 	_widec = (short)(1152 + ((*p) - -128));
 	if ( 
-#line 140 "ext/fastcsv/fastcsv.rl"
+#line 175 "ext/fastcsv/fastcsv.rl"
  (*p) == quote_char  ) _widec += 256;
 	if ( 
-#line 141 "ext/fastcsv/fastcsv.rl"
+#line 176 "ext/fastcsv/fastcsv.rl"
  (*p) == col_sep  ) _widec += 512;
 	switch( _widec ) {
 		case 1280: goto tr2;
@@ -837,7 +840,7 @@ tr2:
       ENCODE;
     }
   }
-#line 122 "ext/fastcsv/fastcsv.rl"
+#line 157 "ext/fastcsv/fastcsv.rl"
 	{
     if (d->start == 0 || p == d->start) { // same as new_row
       rb_ivar_set(self, s_row, rb_str_new2(""));
@@ -854,21 +857,21 @@ tr2:
       rb_yield(row);
     }
   }
-#line 154 "ext/fastcsv/fastcsv.rl"
+#line 189 "ext/fastcsv/fastcsv.rl"
 	{act = 3;}
 	goto st5;
 st5:
 	if ( ++p == pe )
 		goto _test_eof5;
 case 5:
-#line 865 "ext/fastcsv/fastcsv.c"
+#line 868 "ext/fastcsv/fastcsv.c"
 	_widec = (*p);
 	_widec = (short)(1152 + ((*p) - -128));
 	if ( 
-#line 140 "ext/fastcsv/fastcsv.rl"
+#line 175 "ext/fastcsv/fastcsv.rl"
  (*p) == quote_char  ) _widec += 256;
 	if ( 
-#line 141 "ext/fastcsv/fastcsv.rl"
+#line 176 "ext/fastcsv/fastcsv.rl"
  (*p) == col_sep  ) _widec += 512;
 	switch( _widec ) {
 		case 1280: goto tr2;
@@ -904,7 +907,7 @@ tr3:
       ENCODE;
     }
   }
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -915,7 +918,7 @@ tr3:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -929,7 +932,7 @@ tr3:
     rb_yield(row);
     row = rb_ary_new();
   }
-#line 153 "ext/fastcsv/fastcsv.rl"
+#line 188 "ext/fastcsv/fastcsv.rl"
 	{act = 2;}
 	goto st6;
 tr8:
@@ -946,9 +949,9 @@ tr8:
       ENCODE;
     }
   }
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -957,9 +960,9 @@ tr8:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{act = 1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -970,7 +973,7 @@ tr8:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -988,7 +991,7 @@ tr8:
 tr13:
 #line 1 "NONE"
 	{te = p+1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -999,7 +1002,7 @@ tr13:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1013,15 +1016,15 @@ tr13:
     rb_yield(row);
     row = rb_ary_new();
   }
-#line 153 "ext/fastcsv/fastcsv.rl"
+#line 188 "ext/fastcsv/fastcsv.rl"
 	{act = 2;}
 	goto st6;
 tr20:
 #line 1 "NONE"
 	{te = p+1;}
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1030,9 +1033,9 @@ tr20:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{act = 1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -1043,7 +1046,7 @@ tr20:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1061,13 +1064,13 @@ tr20:
 tr38:
 #line 1 "NONE"
 	{te = p+1;}
-#line 153 "ext/fastcsv/fastcsv.rl"
+#line 188 "ext/fastcsv/fastcsv.rl"
 	{act = 2;}
 	goto st6;
 tr46:
 #line 1 "NONE"
 	{te = p+1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -1078,7 +1081,7 @@ tr46:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1092,7 +1095,7 @@ tr46:
     rb_yield(row);
     row = rb_ary_new();
   }
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -1111,15 +1114,15 @@ tr46:
 
     curline++;
   }
-#line 153 "ext/fastcsv/fastcsv.rl"
+#line 188 "ext/fastcsv/fastcsv.rl"
 	{act = 2;}
 	goto st6;
 tr53:
 #line 1 "NONE"
 	{te = p+1;}
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1128,9 +1131,9 @@ tr53:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{act = 1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -1141,7 +1144,7 @@ tr53:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1155,7 +1158,7 @@ tr53:
     rb_yield(row);
     row = rb_ary_new();
   }
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -1179,7 +1182,7 @@ st6:
 	if ( ++p == pe )
 		goto _test_eof6;
 case 6:
-#line 1183 "ext/fastcsv/fastcsv.c"
+#line 1186 "ext/fastcsv/fastcsv.c"
 	goto tr37;
 tr4:
 #line 1 "NONE"
@@ -1195,7 +1198,7 @@ tr4:
       ENCODE;
     }
   }
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -1206,7 +1209,7 @@ tr4:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1220,7 +1223,7 @@ tr4:
     rb_yield(row);
     row = rb_ary_new();
   }
-#line 153 "ext/fastcsv/fastcsv.rl"
+#line 188 "ext/fastcsv/fastcsv.rl"
 	{act = 2;}
 	goto st7;
 tr9:
@@ -1237,9 +1240,9 @@ tr9:
       ENCODE;
     }
   }
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1248,9 +1251,9 @@ tr9:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{act = 1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -1261,7 +1264,7 @@ tr9:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1279,7 +1282,7 @@ tr9:
 tr14:
 #line 1 "NONE"
 	{te = p+1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -1290,7 +1293,7 @@ tr14:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1304,15 +1307,15 @@ tr14:
     rb_yield(row);
     row = rb_ary_new();
   }
-#line 153 "ext/fastcsv/fastcsv.rl"
+#line 188 "ext/fastcsv/fastcsv.rl"
 	{act = 2;}
 	goto st7;
 tr21:
 #line 1 "NONE"
 	{te = p+1;}
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1321,9 +1324,9 @@ tr21:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{act = 1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -1334,7 +1337,7 @@ tr21:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1352,7 +1355,7 @@ tr21:
 tr47:
 #line 1 "NONE"
 	{te = p+1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -1363,7 +1366,7 @@ tr47:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1377,7 +1380,7 @@ tr47:
     rb_yield(row);
     row = rb_ary_new();
   }
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -1396,15 +1399,15 @@ tr47:
 
     curline++;
   }
-#line 153 "ext/fastcsv/fastcsv.rl"
+#line 188 "ext/fastcsv/fastcsv.rl"
 	{act = 2;}
 	goto st7;
 tr54:
 #line 1 "NONE"
 	{te = p+1;}
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1413,9 +1416,9 @@ tr54:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{act = 1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -1426,7 +1429,7 @@ tr54:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1440,7 +1443,7 @@ tr54:
     rb_yield(row);
     row = rb_ary_new();
   }
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -1464,7 +1467,7 @@ st7:
 	if ( ++p == pe )
 		goto _test_eof7;
 case 7:
-#line 1468 "ext/fastcsv/fastcsv.c"
+#line 1471 "ext/fastcsv/fastcsv.c"
 	if ( (*p) == 10 )
 		goto tr38;
 	goto tr37;
@@ -1482,7 +1485,7 @@ tr27:
       ENCODE;
     }
   }
-#line 122 "ext/fastcsv/fastcsv.rl"
+#line 157 "ext/fastcsv/fastcsv.rl"
 	{
     if (d->start == 0 || p == d->start) { // same as new_row
       rb_ivar_set(self, s_row, rb_str_new2(""));
@@ -1499,21 +1502,21 @@ tr27:
       rb_yield(row);
     }
   }
-#line 154 "ext/fastcsv/fastcsv.rl"
+#line 189 "ext/fastcsv/fastcsv.rl"
 	{act = 3;}
 	goto st8;
 st8:
 	if ( ++p == pe )
 		goto _test_eof8;
 case 8:
-#line 1510 "ext/fastcsv/fastcsv.c"
+#line 1513 "ext/fastcsv/fastcsv.c"
 	_widec = (*p);
 	_widec = (short)(1152 + ((*p) - -128));
 	if ( 
-#line 140 "ext/fastcsv/fastcsv.rl"
+#line 175 "ext/fastcsv/fastcsv.rl"
  (*p) == quote_char  ) _widec += 256;
 	if ( 
-#line 141 "ext/fastcsv/fastcsv.rl"
+#line 176 "ext/fastcsv/fastcsv.rl"
  (*p) == col_sep  ) _widec += 512;
 	if ( _widec < 1291 ) {
 		if ( 1152 <= _widec && _widec <= 1289 )
@@ -1532,7 +1535,7 @@ tr28:
   }
 	goto st2;
 tr39:
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -1556,11 +1559,11 @@ st2:
 	if ( ++p == pe )
 		goto _test_eof2;
 case 2:
-#line 1560 "ext/fastcsv/fastcsv.c"
+#line 1563 "ext/fastcsv/fastcsv.c"
 	_widec = (*p);
 	_widec = (short)(128 + ((*p) - -128));
 	if ( 
-#line 140 "ext/fastcsv/fastcsv.rl"
+#line 175 "ext/fastcsv/fastcsv.rl"
  (*p) == quote_char  ) _widec += 256;
 	if ( _widec < 257 ) {
 		if ( 128 <= _widec && _widec <= 255 )
@@ -1574,7 +1577,42 @@ case 2:
 tr11:
 #line 63 "ext/fastcsv/fastcsv.rl"
 	{
-    // intentionally blank - see parse_quoted_field
+    if (!use_parse_quoted_field) {
+      if (p == ts) {
+        field = rb_enc_str_new("", 0, encoding);
+        ENCODE;
+      }
+      // @note If we add an action on '""', we can skip some steps if no '""' is found.
+      else if (p > ts) {
+        // Operating on ts in-place produces odd behavior, FYI.
+        char *copy = ALLOC_N(char, p - ts);
+        memcpy(copy, ts, p - ts);
+
+        char *reader = ts, *writer = copy;
+        int escaped = 0;
+
+        while (p > reader) {
+          if (*reader == quote_char && !escaped) {
+            // Skip the escaping character.
+            escaped = 1;
+          }
+          else {
+            escaped = 0;
+            *writer++ = *reader;
+          }
+          reader++;
+        }
+
+        field = rb_enc_str_new(copy, writer - copy, encoding);
+        ENCODE;
+
+        if (copy != NULL) {
+          free(copy);
+        }
+      }
+    } else {
+      // intentionally blank - see parse_quoted_field
+    }
   }
 #line 48 "ext/fastcsv/fastcsv.rl"
 	{
@@ -1584,13 +1622,48 @@ tr11:
 tr40:
 #line 63 "ext/fastcsv/fastcsv.rl"
 	{
-    // intentionally blank - see parse_quoted_field
+    if (!use_parse_quoted_field) {
+      if (p == ts) {
+        field = rb_enc_str_new("", 0, encoding);
+        ENCODE;
+      }
+      // @note If we add an action on '""', we can skip some steps if no '""' is found.
+      else if (p > ts) {
+        // Operating on ts in-place produces odd behavior, FYI.
+        char *copy = ALLOC_N(char, p - ts);
+        memcpy(copy, ts, p - ts);
+
+        char *reader = ts, *writer = copy;
+        int escaped = 0;
+
+        while (p > reader) {
+          if (*reader == quote_char && !escaped) {
+            // Skip the escaping character.
+            escaped = 1;
+          }
+          else {
+            escaped = 0;
+            *writer++ = *reader;
+          }
+          reader++;
+        }
+
+        field = rb_enc_str_new(copy, writer - copy, encoding);
+        ENCODE;
+
+        if (copy != NULL) {
+          free(copy);
+        }
+      }
+    } else {
+      // intentionally blank - see parse_quoted_field
+    }
   }
 #line 48 "ext/fastcsv/fastcsv.rl"
 	{
     unclosed_line = 0;
   }
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -1614,14 +1687,14 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 1618 "ext/fastcsv/fastcsv.c"
+#line 1691 "ext/fastcsv/fastcsv.c"
 	_widec = (*p);
 	_widec = (short)(1152 + ((*p) - -128));
 	if ( 
-#line 140 "ext/fastcsv/fastcsv.rl"
+#line 175 "ext/fastcsv/fastcsv.rl"
  (*p) == quote_char  ) _widec += 256;
 	if ( 
-#line 141 "ext/fastcsv/fastcsv.rl"
+#line 176 "ext/fastcsv/fastcsv.rl"
  (*p) == col_sep  ) _widec += 512;
 	switch( _widec ) {
 		case 1280: goto tr12;
@@ -1649,7 +1722,7 @@ case 3:
 tr15:
 #line 1 "NONE"
 	{te = p+1;}
-#line 122 "ext/fastcsv/fastcsv.rl"
+#line 157 "ext/fastcsv/fastcsv.rl"
 	{
     if (d->start == 0 || p == d->start) { // same as new_row
       rb_ivar_set(self, s_row, rb_str_new2(""));
@@ -1666,15 +1739,15 @@ tr15:
       rb_yield(row);
     }
   }
-#line 154 "ext/fastcsv/fastcsv.rl"
+#line 189 "ext/fastcsv/fastcsv.rl"
 	{act = 3;}
 	goto st9;
 tr22:
 #line 1 "NONE"
 	{te = p+1;}
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1683,15 +1756,15 @@ tr22:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{act = 1;}
 	goto st9;
 tr23:
 #line 1 "NONE"
 	{te = p+1;}
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1700,9 +1773,9 @@ tr23:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{act = 1;}
-#line 122 "ext/fastcsv/fastcsv.rl"
+#line 157 "ext/fastcsv/fastcsv.rl"
 	{
     if (d->start == 0 || p == d->start) { // same as new_row
       rb_ivar_set(self, s_row, rb_str_new2(""));
@@ -1739,7 +1812,7 @@ tr29:
       ENCODE;
     }
   }
-#line 122 "ext/fastcsv/fastcsv.rl"
+#line 157 "ext/fastcsv/fastcsv.rl"
 	{
     if (d->start == 0 || p == d->start) { // same as new_row
       rb_ivar_set(self, s_row, rb_str_new2(""));
@@ -1756,7 +1829,7 @@ tr29:
       rb_yield(row);
     }
   }
-#line 154 "ext/fastcsv/fastcsv.rl"
+#line 189 "ext/fastcsv/fastcsv.rl"
 	{act = 3;}
 	goto st9;
 tr32:
@@ -1778,9 +1851,9 @@ tr32:
     unclosed_line = curline;
     in_quoted_field = true;
   }
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1789,7 +1862,7 @@ tr32:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{act = 1;}
 	goto st9;
 tr33:
@@ -1811,9 +1884,9 @@ tr33:
     unclosed_line = curline;
     in_quoted_field = true;
   }
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1822,9 +1895,9 @@ tr33:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{act = 1;}
-#line 122 "ext/fastcsv/fastcsv.rl"
+#line 157 "ext/fastcsv/fastcsv.rl"
 	{
     if (d->start == 0 || p == d->start) { // same as new_row
       rb_ivar_set(self, s_row, rb_str_new2(""));
@@ -1845,7 +1918,7 @@ tr33:
 tr48:
 #line 1 "NONE"
 	{te = p+1;}
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -1864,7 +1937,7 @@ tr48:
 
     curline++;
   }
-#line 122 "ext/fastcsv/fastcsv.rl"
+#line 157 "ext/fastcsv/fastcsv.rl"
 	{
     if (d->start == 0 || p == d->start) { // same as new_row
       rb_ivar_set(self, s_row, rb_str_new2(""));
@@ -1881,15 +1954,15 @@ tr48:
       rb_yield(row);
     }
   }
-#line 154 "ext/fastcsv/fastcsv.rl"
+#line 189 "ext/fastcsv/fastcsv.rl"
 	{act = 3;}
 	goto st9;
 tr55:
 #line 1 "NONE"
 	{te = p+1;}
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1898,9 +1971,9 @@ tr55:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{act = 1;}
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -1923,9 +1996,9 @@ tr55:
 tr56:
 #line 1 "NONE"
 	{te = p+1;}
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -1934,9 +2007,9 @@ tr56:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{act = 1;}
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -1955,7 +2028,7 @@ tr56:
 
     curline++;
   }
-#line 122 "ext/fastcsv/fastcsv.rl"
+#line 157 "ext/fastcsv/fastcsv.rl"
 	{
     if (d->start == 0 || p == d->start) { // same as new_row
       rb_ivar_set(self, s_row, rb_str_new2(""));
@@ -1977,11 +2050,11 @@ st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 1981 "ext/fastcsv/fastcsv.c"
+#line 2054 "ext/fastcsv/fastcsv.c"
 	_widec = (*p);
 	_widec = (short)(128 + ((*p) - -128));
 	if ( 
-#line 140 "ext/fastcsv/fastcsv.rl"
+#line 175 "ext/fastcsv/fastcsv.rl"
  (*p) == quote_char  ) _widec += 256;
 	if ( _widec < 257 ) {
 		if ( 128 <= _widec && _widec <= 255 )
@@ -1995,7 +2068,7 @@ case 9:
 tr16:
 #line 1 "NONE"
 	{te = p+1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -2006,7 +2079,7 @@ tr16:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -2020,15 +2093,15 @@ tr16:
     rb_yield(row);
     row = rb_ary_new();
   }
-#line 153 "ext/fastcsv/fastcsv.rl"
+#line 188 "ext/fastcsv/fastcsv.rl"
 	{act = 2;}
 	goto st10;
 tr24:
 #line 1 "NONE"
 	{te = p+1;}
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -2037,9 +2110,9 @@ tr24:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{act = 1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -2050,7 +2123,7 @@ tr24:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -2084,7 +2157,7 @@ tr30:
       ENCODE;
     }
   }
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -2095,7 +2168,7 @@ tr30:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -2109,7 +2182,7 @@ tr30:
     rb_yield(row);
     row = rb_ary_new();
   }
-#line 153 "ext/fastcsv/fastcsv.rl"
+#line 188 "ext/fastcsv/fastcsv.rl"
 	{act = 2;}
 	goto st10;
 tr34:
@@ -2131,9 +2204,9 @@ tr34:
     unclosed_line = curline;
     in_quoted_field = true;
   }
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -2142,9 +2215,9 @@ tr34:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{act = 1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -2155,7 +2228,7 @@ tr34:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -2173,7 +2246,7 @@ tr34:
 tr41:
 #line 1 "NONE"
 	{te = p+1;}
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -2192,13 +2265,13 @@ tr41:
 
     curline++;
   }
-#line 153 "ext/fastcsv/fastcsv.rl"
+#line 188 "ext/fastcsv/fastcsv.rl"
 	{act = 2;}
 	goto st10;
 tr49:
 #line 1 "NONE"
 	{te = p+1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -2209,7 +2282,7 @@ tr49:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -2223,7 +2296,7 @@ tr49:
     rb_yield(row);
     row = rb_ary_new();
   }
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -2242,15 +2315,15 @@ tr49:
 
     curline++;
   }
-#line 153 "ext/fastcsv/fastcsv.rl"
+#line 188 "ext/fastcsv/fastcsv.rl"
 	{act = 2;}
 	goto st10;
 tr57:
 #line 1 "NONE"
 	{te = p+1;}
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -2259,9 +2332,9 @@ tr57:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{act = 1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -2272,7 +2345,7 @@ tr57:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -2286,7 +2359,7 @@ tr57:
     rb_yield(row);
     row = rb_ary_new();
   }
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -2310,11 +2383,11 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 2314 "ext/fastcsv/fastcsv.c"
+#line 2387 "ext/fastcsv/fastcsv.c"
 	_widec = (*p);
 	_widec = (short)(128 + ((*p) - -128));
 	if ( 
-#line 140 "ext/fastcsv/fastcsv.rl"
+#line 175 "ext/fastcsv/fastcsv.rl"
  (*p) == quote_char  ) _widec += 256;
 	if ( _widec == 256 )
 		goto tr37;
@@ -2327,7 +2400,7 @@ case 10:
 tr17:
 #line 1 "NONE"
 	{te = p+1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -2338,7 +2411,7 @@ tr17:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -2352,15 +2425,15 @@ tr17:
     rb_yield(row);
     row = rb_ary_new();
   }
-#line 153 "ext/fastcsv/fastcsv.rl"
+#line 188 "ext/fastcsv/fastcsv.rl"
 	{act = 2;}
 	goto st11;
 tr25:
 #line 1 "NONE"
 	{te = p+1;}
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -2369,9 +2442,9 @@ tr25:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{act = 1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -2382,7 +2455,7 @@ tr25:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -2416,7 +2489,7 @@ tr31:
       ENCODE;
     }
   }
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -2427,7 +2500,7 @@ tr31:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -2441,7 +2514,7 @@ tr31:
     rb_yield(row);
     row = rb_ary_new();
   }
-#line 153 "ext/fastcsv/fastcsv.rl"
+#line 188 "ext/fastcsv/fastcsv.rl"
 	{act = 2;}
 	goto st11;
 tr35:
@@ -2463,9 +2536,9 @@ tr35:
     unclosed_line = curline;
     in_quoted_field = true;
   }
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -2474,9 +2547,9 @@ tr35:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{act = 1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -2487,7 +2560,7 @@ tr35:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -2505,7 +2578,7 @@ tr35:
 tr50:
 #line 1 "NONE"
 	{te = p+1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -2516,7 +2589,7 @@ tr50:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -2530,7 +2603,7 @@ tr50:
     rb_yield(row);
     row = rb_ary_new();
   }
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -2549,15 +2622,15 @@ tr50:
 
     curline++;
   }
-#line 153 "ext/fastcsv/fastcsv.rl"
+#line 188 "ext/fastcsv/fastcsv.rl"
 	{act = 2;}
 	goto st11;
 tr58:
 #line 1 "NONE"
 	{te = p+1;}
-#line 67 "ext/fastcsv/fastcsv.rl"
+#line 102 "ext/fastcsv/fastcsv.rl"
 	{
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -2566,9 +2639,9 @@ tr58:
     rb_ary_push(row, field);
     field = Qnil;
   }
-#line 152 "ext/fastcsv/fastcsv.rl"
+#line 187 "ext/fastcsv/fastcsv.rl"
 	{act = 1;}
-#line 97 "ext/fastcsv/fastcsv.rl"
+#line 132 "ext/fastcsv/fastcsv.rl"
 	{
     mark_row_sep = p;
 
@@ -2579,7 +2652,7 @@ tr58:
       rb_ivar_set(self, s_row, rb_str_new(d->start, p - d->start));
     }
 
-    if (in_quoted_field) {
+    if (use_parse_quoted_field && in_quoted_field) {
       parse_quoted_field(&field, encoding, quote_char, ts + 1, p - 1);
       ENCODE;
       in_quoted_field = false;
@@ -2593,7 +2666,7 @@ tr58:
     rb_yield(row);
     row = rb_ary_new();
   }
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -2617,11 +2690,11 @@ st11:
 	if ( ++p == pe )
 		goto _test_eof11;
 case 11:
-#line 2621 "ext/fastcsv/fastcsv.c"
+#line 2694 "ext/fastcsv/fastcsv.c"
 	_widec = (*p);
 	_widec = (short)(128 + ((*p) - -128));
 	if ( 
-#line 140 "ext/fastcsv/fastcsv.rl"
+#line 175 "ext/fastcsv/fastcsv.rl"
  (*p) == quote_char  ) _widec += 256;
 	switch( _widec ) {
 		case 256: goto tr37;
@@ -2639,13 +2712,48 @@ tr42:
 	{te = p+1;}
 #line 63 "ext/fastcsv/fastcsv.rl"
 	{
-    // intentionally blank - see parse_quoted_field
+    if (!use_parse_quoted_field) {
+      if (p == ts) {
+        field = rb_enc_str_new("", 0, encoding);
+        ENCODE;
+      }
+      // @note If we add an action on '""', we can skip some steps if no '""' is found.
+      else if (p > ts) {
+        // Operating on ts in-place produces odd behavior, FYI.
+        char *copy = ALLOC_N(char, p - ts);
+        memcpy(copy, ts, p - ts);
+
+        char *reader = ts, *writer = copy;
+        int escaped = 0;
+
+        while (p > reader) {
+          if (*reader == quote_char && !escaped) {
+            // Skip the escaping character.
+            escaped = 1;
+          }
+          else {
+            escaped = 0;
+            *writer++ = *reader;
+          }
+          reader++;
+        }
+
+        field = rb_enc_str_new(copy, writer - copy, encoding);
+        ENCODE;
+
+        if (copy != NULL) {
+          free(copy);
+        }
+      }
+    } else {
+      // intentionally blank - see parse_quoted_field
+    }
   }
 #line 48 "ext/fastcsv/fastcsv.rl"
 	{
     unclosed_line = 0;
   }
-#line 78 "ext/fastcsv/fastcsv.rl"
+#line 113 "ext/fastcsv/fastcsv.rl"
 	{
     d->start = p;
 
@@ -2664,21 +2772,21 @@ tr42:
 
     curline++;
   }
-#line 153 "ext/fastcsv/fastcsv.rl"
+#line 188 "ext/fastcsv/fastcsv.rl"
 	{act = 2;}
 	goto st12;
 st12:
 	if ( ++p == pe )
 		goto _test_eof12;
 case 12:
-#line 2675 "ext/fastcsv/fastcsv.c"
+#line 2783 "ext/fastcsv/fastcsv.c"
 	_widec = (*p);
 	_widec = (short)(1152 + ((*p) - -128));
 	if ( 
-#line 140 "ext/fastcsv/fastcsv.rl"
+#line 175 "ext/fastcsv/fastcsv.rl"
  (*p) == quote_char  ) _widec += 256;
 	if ( 
-#line 141 "ext/fastcsv/fastcsv.rl"
+#line 176 "ext/fastcsv/fastcsv.rl"
  (*p) == col_sep  ) _widec += 512;
 	switch( _widec ) {
 		case 1280: goto tr45;
@@ -2741,7 +2849,7 @@ case 12:
 	_out: {}
 	}
 
-#line 465 "ext/fastcsv/fastcsv.rl"
+#line 503 "ext/fastcsv/fastcsv.rl"
 
     if (done && cs < raw_parse_first_final) {
       if (d->start == 0 || p == d->start) { // same as new_row


### PR DESCRIPTION
For easy testing, add a boolean option, `use_parse_quoted_field`, to toggle between the old and new implementations (see #1)